### PR TITLE
Fix Delsys streamer issues with streaming both EMG and IMU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,11 @@ media/*
 *.exe
 test_*.py
 *.csv
-.vscode/*
 test_delsys_api.py
 resources/
 __pycache__/    # This ignores the pycache directory
 *.py[cod]       # This ignores .pyc, .pyo, and .pyd files
 *$py.class      # This ignores Python class files
 *.pyc
+.github/*
+.idea/*

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -1,3 +1,4 @@
+import traceback
 from abc import ABC, abstractmethod
 from typing import Callable, Sequence
 import numpy as np


### PR DESCRIPTION
Rather than using threading, use [selectors](https://docs.python.org/3/library/selectors.html). They provide high-speed multiplexing between sockets and auto detect when data is available. Avoids a whole host of issues with threading, locking, etc.

Given that there is usually a 13.5ms delay between packets in Delsys, we have some room to do multiplexing. In the past, this has worked for me. Quick pilot testing with visualization on the VR computer seems to indicate that it is still working as intended.